### PR TITLE
Use `gpiozero` instead of `RPi.GPIO`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,4 @@ install_requires =
   pyserial
   click
   pexpect
+  gpiozero

--- a/silabs-flasher
+++ b/silabs-flasher
@@ -183,6 +183,8 @@ async def flash(ctx, firmware, ezsp_reset, cm4_gpio_reset):
             ezsp.close()
         ezsp = None
     if cm4_gpio_reset:
+        os.environ.setdefault("GPIOZERO_PIN_FACTORY", "native")
+
         with OutputDevice(pin=24, initial_value=True) as gpio24, \
              OutputDevice(pin=25, initial_value=True) as gpio25:
             gpio24.off()  # Assert Reset

--- a/silabs-flasher
+++ b/silabs-flasher
@@ -19,6 +19,7 @@ import re
 import pexpect
 from pexpect import fdpexpect
 
+from gpiozero import OutputDevice
 from xmodem import XMODEM
 
 LOGGER = logging.getLogger(__name__)
@@ -182,20 +183,17 @@ async def flash(ctx, firmware, ezsp_reset, cm4_gpio_reset):
             ezsp.close()
         ezsp = None
     if cm4_gpio_reset:
-        import RPi.GPIO as GPIO
-        GPIO.setmode(GPIO.BCM)
-        GPIO.setup(24, GPIO.OUT, initial=GPIO.HIGH)
-        GPIO.setup(25, GPIO.OUT, initial=GPIO.HIGH)
+        with OutputDevice(pin=24, initial_value=True) as gpio24, \
+             OutputDevice(pin=25, initial_value=True) as gpio25:
+            gpio24.off()  # Assert Reset
+            gpio25.off()  # 0=BL mode, 1=Firmware
+            time.sleep(0.1)
+            gpio25.on()  # Deassert Reset
+            time.sleep(0.1)
 
-        GPIO.output(25, 0) # Assert Reset
-        GPIO.output(24, 0) # 0=BL mode, 1=Firmware
-        time.sleep(0.1)
-        GPIO.output(25, 1) # Deassert Reset
-        time.sleep(0.1)
-        # This clears all GPIO leaving them as input/without pulls
+        # Context manager clears all GPIO leaving them as input/without pulls
         # External pulls will make sure the SoC will enter Firmware
         # on next reset.
-        GPIO.cleanup()
 
     upload_firmware(device, baudrate, firmware)
 


### PR DESCRIPTION
Works for me with experimental "native" pin factory on the Yellow:

```console
bash-5.1# silabs-flasher --device=/dev/ttyAMA1 flash --cm4-gpio-reset --firmware NabuCasa_EZSP_v7.1.1.0_PA32_ncp-uart-hw_115200.gbl
Trying to connect using EZSP...
Launching bootloader in mode recovery mode via EZSP.
Bootloader detected successfully.
Bootloader version: 2.00.01
Starting firmware upload...
Firmware update  [####################################]  100%
Bootloader reported successful upload.
Starting flashed firmware...
```

I think it'll be fine for low-speed switching. Or we can just expect people to `pip install RPi.GPIO` as well when they see the error?